### PR TITLE
LUT-29890

### DIFF
--- a/src/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentService.java
+++ b/src/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentService.java
@@ -158,6 +158,7 @@ public class IdentityAttributeGeocodesAdjustmentService
                 // Country doesn't exist in Geocodes for provided code : discard attribute and notify with an AttributeStatus
                 request.getIdentity( ).getAttributes( ).remove( sentCountryCode );
                 if ( sentCountryLabel != null ) {
+                    // When the code is incorrect, we discard the label as well
                     request.getIdentity( ).getAttributes( ).remove( sentCountryLabel );
                 }
 
@@ -297,6 +298,10 @@ public class IdentityAttributeGeocodesAdjustmentService
                     {
                         // city doesn't exist in Geocodes for provided code, and code is not FC certified : discard attribute and notify with an AttributeStatus
                         request.getIdentity().getAttributes().remove(sentCityCode);
+                        if ( sentCityLabel != null ) {
+                            // When the code is incorrect, we discard the label as well
+                            request.getIdentity( ).getAttributes( ).remove( sentCityLabel );
+                        }
 
                         final AttributeStatus attributeStatus = new AttributeStatus();
                         attributeStatus.setKey(sentCityCode.getKey());
@@ -330,6 +335,10 @@ public class IdentityAttributeGeocodesAdjustmentService
                 {
                     // The provided city code is linked to multiples cities
                     request.getIdentity().getAttributes().remove(sentCityCode);
+                    if ( sentCityLabel != null ) {
+                        // When the code is incorrect, we discard the label as well
+                        request.getIdentity( ).getAttributes( ).remove( sentCityLabel );
+                    }
 
                     final AttributeStatus attributeStatus = new AttributeStatus();
                     attributeStatus.setKey(sentCityCode.getKey());
@@ -344,6 +353,7 @@ public class IdentityAttributeGeocodesAdjustmentService
                 // city doesn't exist in Geocodes for provided code
                 request.getIdentity().getAttributes().remove(sentCityCode);
                 if ( sentCityLabel != null ) {
+                    // When the code is incorrect, we discard the label as well
                     request.getIdentity( ).getAttributes( ).remove( sentCityLabel );
                 }
 

--- a/src/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentService.java
+++ b/src/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentService.java
@@ -157,6 +157,9 @@ public class IdentityAttributeGeocodesAdjustmentService
             {
                 // Country doesn't exist in Geocodes for provided code : discard attribute and notify with an AttributeStatus
                 request.getIdentity( ).getAttributes( ).remove( sentCountryCode );
+                if ( sentCountryLabel != null ) {
+                    request.getIdentity( ).getAttributes( ).remove( sentCountryLabel );
+                }
 
                 final AttributeStatus attributeStatus = new AttributeStatus( );
                 attributeStatus.setKey( sentCountryCode.getKey( ) );
@@ -340,6 +343,9 @@ public class IdentityAttributeGeocodesAdjustmentService
             {
                 // city doesn't exist in Geocodes for provided code
                 request.getIdentity().getAttributes().remove(sentCityCode);
+                if ( sentCityLabel != null ) {
+                    request.getIdentity( ).getAttributes( ).remove( sentCityLabel );
+                }
 
                 final AttributeStatus attributeStatus = new AttributeStatus();
                 attributeStatus.setKey(sentCityCode.getKey());

--- a/src/java/fr/paris/lutece/plugins/identitystore/v3/web/request/identity/IdentityStoreUpdateRequest.java
+++ b/src/java/fr/paris/lutece/plugins/identitystore/v3/web/request/identity/IdentityStoreUpdateRequest.java
@@ -44,7 +44,6 @@ import fr.paris.lutece.plugins.identitystore.v3.web.request.AbstractIdentityStor
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityAttributeValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityDuplicateValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityValidator;
-import fr.paris.lutece.plugins.identitystore.v3.web.rs.DtoConverter;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.IdentityRequestValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.dto.common.AttributeChangeStatus;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.dto.common.AttributeChangeStatusType;
@@ -187,34 +186,17 @@ public class IdentityStoreUpdateRequest extends AbstractIdentityStoreAppCodeRequ
             return response;
         }
 
-        final Pair<Identity, List<AttributeStatus>> result;
-        ResponseStatus responseStatus = null;
-        if ( _identityChangeRequest.getIdentity( ).getAttributes( ).isEmpty( ) &&
-             ( _identityChangeRequest.getIdentity( ).getConnectionId( ) == null ||
-               _identityChangeRequest.getIdentity( ).getConnectionId( ).equals( existingIdentityToUpdate.getConnectionId( ) ) ) &&
-             ( _identityChangeRequest.getIdentity( ).getMonParisActive( ) == null ||
-               _identityChangeRequest.getIdentity().getMonParisActive().equals( existingIdentityToUpdate.getMonParisActive( ) ) ) )
-        {
-            // if there is no changes to perform after the request validations, skip the update and send back a 400 BAD REQUEST
-            result = Pair.of( DtoConverter.convertDtoToIdentity( existingIdentityToUpdate ), List.of( ) );
-            responseStatus = ResponseStatusFactory.badRequest( );
-        }
-        else
-        {
-            // perform update
-            result = IdentityService.instance( ).update( _strCustomerId, _identityChangeRequest, _author, serviceContract, formatStatuses );
-        }
+        // perform update
+        final Pair<Identity, List<AttributeStatus>> result = IdentityService.instance( ).update( _strCustomerId, _identityChangeRequest, _author,
+                serviceContract, formatStatuses );
 
         final Identity updatedIdentity = result.getKey( );
-        final List<AttributeStatus> attrStatusList = new ArrayList<>( result.getValue( ) );
+        final List<AttributeStatus> attrStatusList = result.getValue( );
         attrStatusList.addAll( formatStatuses );
 
         final boolean allAttributesCreatedOrUpdated = attrStatusList.stream( ).map( AttributeStatus::getStatus )
                 .allMatch( status -> status.getType( ) == AttributeChangeStatusType.SUCCESS );
-
-        if ( responseStatus == null ) {
-            responseStatus = allAttributesCreatedOrUpdated ? ResponseStatusFactory.success( ) : ResponseStatusFactory.incompleteSuccess( );
-        }
+        final ResponseStatus status = allAttributesCreatedOrUpdated ? ResponseStatusFactory.success( ) : ResponseStatusFactory.incompleteSuccess( );
 
         final String msgKey;
         if ( Collections.disjoint( AttributeChangeStatus.getSuccessStatuses( ),
@@ -228,7 +210,7 @@ public class IdentityStoreUpdateRequest extends AbstractIdentityStoreAppCodeRequ
             msgKey = Constants.PROPERTY_REST_INFO_SUCCESSFUL_OPERATION;
         }
 
-        response.setStatus( responseStatus.setAttributeStatuses( attrStatusList ).setMessageKey( msgKey ) );
+        response.setStatus( status.setAttributeStatuses( attrStatusList ).setMessageKey( msgKey ) );
         response.setCustomerId( updatedIdentity.getCustomerId( ) );
         response.setConnectionId( updatedIdentity.getConnectionId( ) );
         response.setCreationDate( updatedIdentity.getCreationDate( ) );

--- a/src/java/fr/paris/lutece/plugins/identitystore/v3/web/request/identity/IdentityStoreUpdateRequest.java
+++ b/src/java/fr/paris/lutece/plugins/identitystore/v3/web/request/identity/IdentityStoreUpdateRequest.java
@@ -44,6 +44,7 @@ import fr.paris.lutece.plugins.identitystore.v3.web.request.AbstractIdentityStor
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityAttributeValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityDuplicateValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.request.validator.IdentityValidator;
+import fr.paris.lutece.plugins.identitystore.v3.web.rs.DtoConverter;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.IdentityRequestValidator;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.dto.common.AttributeChangeStatus;
 import fr.paris.lutece.plugins.identitystore.v3.web.rs.dto.common.AttributeChangeStatusType;
@@ -186,17 +187,34 @@ public class IdentityStoreUpdateRequest extends AbstractIdentityStoreAppCodeRequ
             return response;
         }
 
-        // perform update
-        final Pair<Identity, List<AttributeStatus>> result = IdentityService.instance( ).update( _strCustomerId, _identityChangeRequest, _author,
-                serviceContract, formatStatuses );
+        final Pair<Identity, List<AttributeStatus>> result;
+        ResponseStatus responseStatus = null;
+        if ( _identityChangeRequest.getIdentity( ).getAttributes( ).isEmpty( ) &&
+             ( _identityChangeRequest.getIdentity( ).getConnectionId( ) == null ||
+               _identityChangeRequest.getIdentity( ).getConnectionId( ).equals( existingIdentityToUpdate.getConnectionId( ) ) ) &&
+             ( _identityChangeRequest.getIdentity( ).getMonParisActive( ) == null ||
+               _identityChangeRequest.getIdentity().getMonParisActive().equals( existingIdentityToUpdate.getMonParisActive( ) ) ) )
+        {
+            // if there is no changes to perform after the request validations, skip the update and send back a 400 BAD REQUEST
+            result = Pair.of( DtoConverter.convertDtoToIdentity( existingIdentityToUpdate ), List.of( ) );
+            responseStatus = ResponseStatusFactory.badRequest( );
+        }
+        else
+        {
+            // perform update
+            result = IdentityService.instance( ).update( _strCustomerId, _identityChangeRequest, _author, serviceContract, formatStatuses );
+        }
 
         final Identity updatedIdentity = result.getKey( );
-        final List<AttributeStatus> attrStatusList = result.getValue( );
+        final List<AttributeStatus> attrStatusList = new ArrayList<>( result.getValue( ) );
         attrStatusList.addAll( formatStatuses );
 
         final boolean allAttributesCreatedOrUpdated = attrStatusList.stream( ).map( AttributeStatus::getStatus )
                 .allMatch( status -> status.getType( ) == AttributeChangeStatusType.SUCCESS );
-        final ResponseStatus status = allAttributesCreatedOrUpdated ? ResponseStatusFactory.success( ) : ResponseStatusFactory.incompleteSuccess( );
+
+        if ( responseStatus == null ) {
+            responseStatus = allAttributesCreatedOrUpdated ? ResponseStatusFactory.success( ) : ResponseStatusFactory.incompleteSuccess( );
+        }
 
         final String msgKey;
         if ( Collections.disjoint( AttributeChangeStatus.getSuccessStatuses( ),
@@ -210,7 +228,7 @@ public class IdentityStoreUpdateRequest extends AbstractIdentityStoreAppCodeRequ
             msgKey = Constants.PROPERTY_REST_INFO_SUCCESSFUL_OPERATION;
         }
 
-        response.setStatus( status.setAttributeStatuses( attrStatusList ).setMessageKey( msgKey ) );
+        response.setStatus( responseStatus.setAttributeStatuses( attrStatusList ).setMessageKey( msgKey ) );
         response.setCustomerId( updatedIdentity.getCustomerId( ) );
         response.setConnectionId( updatedIdentity.getConnectionId( ) );
         response.setCreationDate( updatedIdentity.getCreationDate( ) );

--- a/src/test/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentServiceTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/identitystore/service/attribute/IdentityAttributeGeocodesAdjustmentServiceTest.java
@@ -12,10 +12,11 @@ import java.util.List;
 
 public class IdentityAttributeGeocodesAdjustmentServiceTest extends LuteceTestCase
 {
-    protected static final String BIRTHPLACE_CODE_MULTIPLE = "01053";
-    protected static final String BIRTHPLACE_CODE_UNIQUE = "75201";
-    protected static final String BIRTHPLACE_NAME_UNIQUE = "PARIS 1ER ARROND";
+    protected static final String BIRTHPLACE_CODE_MULTIPLE = "1004";
+    protected static final String BIRTHPLACE_CODE_UNIQUE = "34172";
+    protected static final String BIRTHPLACE_NAME_UNIQUE = "MONTPELLIER";
     protected static final String BIRTHPLACE_NAME_GERMAN = "BERLIN";
+    protected static final String BIRTHPLACE_NAME_ERROR = "MONTPELLIERRRRR";
     protected static final String COUNTRY_CODE_FRANCE = "99100";
     protected static final String COUNTRY_CODE_GERMANY = "99109";
     protected static final String COUNTRY_NAME_FRANCE = "FRANCE";
@@ -158,20 +159,126 @@ public class IdentityAttributeGeocodesAdjustmentServiceTest extends LuteceTestCa
     }
 
     public void testCityCodeOnlyNoCountry() {
-    // Initialize objects
-    List<AttributeDto> attributeDtoList = new ArrayList<AttributeDto>( );
-    attributeDtoList.add( this.createAttribute(KEY_BIRTHPLACE_CODE, BIRTHPLACE_CODE_UNIQUE) );
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<AttributeDto>( );
+        attributeDtoList.add( this.createAttribute(KEY_BIRTHPLACE_CODE, BIRTHPLACE_CODE_UNIQUE) );
 
-    IdentityChangeRequest request = this.createRequest(attributeDtoList);
-    IdentityDto existingIdentity = this.createExistingIdentityBase();
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
 
-    // Create test
-    List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
-    System.out.println( " -=-=-=-=-=-=-=-= retour testCityCodeOnlyNoCountry : " + attributeStatusList.toString());
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCityCodeOnlyNoCountry : " + attributeStatusList.toString());
 
-    // Assert
-    assertTrue(attributeStatusList.isEmpty());
-}
+        // Assert
+        assertTrue(attributeStatusList.isEmpty());
+    }
+
+    public void testCityNameOnlyNoCode() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHPLACE, BIRTHPLACE_NAME_UNIQUE ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCityNameOnlyNoCode : " + attributeStatusList.toString());
+
+        // Assert
+        assertTrue(attributeStatusList.isEmpty());
+        assertEquals(2, request.getIdentity().getAttributes().size());
+        assertTrue(request.getIdentity().getAttributes().stream().anyMatch(a -> a.getKey().equals(KEY_BIRTHPLACE_CODE)));
+    }
+
+    public void testCountryNameOnlyNoCode() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHCOUNTRY, COUNTRY_NAME_FRANCE ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCountryNameOnlyNoCode : " + attributeStatusList.toString());
+
+        // Assert
+        assertTrue(attributeStatusList.isEmpty());
+        assertEquals(2, request.getIdentity().getAttributes().size());
+        assertTrue(request.getIdentity().getAttributes().stream().anyMatch(a -> a.getKey().equals(KEY_BIRTHCOUNTRY_CODE)));
+    }
+
+    public void testCountryWrongNameOnly() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHCOUNTRY, COUNTRY_NAME_FRANCE_ERROR ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCountryWrongNameOnly : " + attributeStatusList.toString());
+
+        // Assert
+        assertFalse(attributeStatusList.isEmpty());
+        assertTrue(request.getIdentity().getAttributes().isEmpty());
+    }
+
+    public void testCountryWrongCodeAndName() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHCOUNTRY_CODE, "ERROR" ) );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHCOUNTRY, COUNTRY_NAME_FRANCE_ERROR ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCountryWrongNameOnly : " + attributeStatusList.toString());
+
+        // Assert
+        assertFalse(attributeStatusList.isEmpty());
+        assertTrue(request.getIdentity().getAttributes().isEmpty());
+    }
+
+    public void testCityWrongNameOnly() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHPLACE, BIRTHPLACE_NAME_ERROR ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCityWrongNameOnly : " + attributeStatusList.toString());
+
+        // Assert
+        assertFalse(attributeStatusList.isEmpty());
+        assertTrue(request.getIdentity().getAttributes().isEmpty());
+    }
+
+    public void testCityWrongCodeAndName() {
+        // Initialize objects
+        List<AttributeDto> attributeDtoList = new ArrayList<>( );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHPLACE_CODE, "ERROR" ) );
+        attributeDtoList.add( this.createAttribute( KEY_BIRTHPLACE, BIRTHPLACE_NAME_ERROR ) );
+
+        IdentityChangeRequest request = this.createRequest(attributeDtoList);
+        IdentityDto existingIdentity = this.createExistingIdentityBase();
+
+        // Create test
+        List<AttributeStatus> attributeStatusList = IdentityAttributeGeocodesAdjustmentService.instance().adjustGeocodesAttributes(request, existingIdentity);
+        System.out.println( " -=-=-=-=-=-=-=-= retour testCityWrongNameOnly : " + attributeStatusList.toString());
+
+        // Assert
+        assertFalse(attributeStatusList.isEmpty());
+        assertTrue(request.getIdentity().getAttributes().isEmpty());
+    }
 
     public void testFranceToOtherCountry() {
         // Initialize objects


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/29890
FIX - Identity update/create - discard sent city/country label when sent code is invalid + send back 400 when no update has been done